### PR TITLE
Combiners, added static branching, plotting, summary data and leaflet html map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@
 # Specific files/dirs to ignore for this pipeline
 */tmp/*
 _targets/*
-3_visualize/out/*
+*/out/*
 **/.DS_Store
+

--- a/2_process/src/summarize_targets.R
+++ b/2_process/src/summarize_targets.R
@@ -1,0 +1,8 @@
+summarize_targets <- function(ind_file, ...) {
+  ind_tbl <- tar_meta(c(...)) %>%
+    select(tar_name = name, filepath = path, hash = data) %>%
+    mutate(filepath = unlist(filepath))
+
+  readr::write_csv(ind_tbl, ind_file)
+  return(ind_file)
+}

--- a/2_process/src/tally_site_obs.R
+++ b/2_process/src/tally_site_obs.R
@@ -9,3 +9,8 @@ tally_site_obs <- function(site_data) {
     group_by(Site, State, Year) %>%
     summarize(NumObs = length(which(!is.na(Value))), .groups = "keep")
 }
+
+# combiner
+combine_obs_tallies <- function(...) {
+bind_rows(...)
+}

--- a/3_visualize/log/summary_state_timeseries.csv
+++ b/3_visualize/log/summary_state_timeseries.csv
@@ -1,6 +1,7 @@
 tar_name,filepath,hash
-timeseries_png_WI,NA,ed8928e05aed0a4b
-timeseries_png_MN,NA,3c568fb37a82ee7e
-timeseries_png_MI,NA,0392ac1d0bd40d99
-timeseries_png_IL,NA,2359190d88d706eb
-timeseries_png_IN,NA,50d1b14d5c5b951f
+timeseries_png_WI,3_visualize/out/timeseries_WI.png,e03c63bb13a97a61
+timeseries_png_MN,3_visualize/out/timeseries_MN.png,d8f904f220bed126
+timeseries_png_MI,3_visualize/out/timeseries_MI.png,101bb4102b9df390
+timeseries_png_IL,3_visualize/out/timeseries_IL.png,c5b3a1c198bf3303
+timeseries_png_IN,3_visualize/out/timeseries_IN.png,c4fc2b594d95d5ef
+timeseries_png_KY,3_visualize/out/timeseries_KY.png,791a6b1a4a9b7aa5

--- a/3_visualize/log/summary_state_timeseries.csv
+++ b/3_visualize/log/summary_state_timeseries.csv
@@ -1,0 +1,6 @@
+tar_name,filepath,hash
+timeseries_png_WI,NA,ed8928e05aed0a4b
+timeseries_png_MN,NA,3c568fb37a82ee7e
+timeseries_png_MI,NA,0392ac1d0bd40d99
+timeseries_png_IL,NA,2359190d88d706eb
+timeseries_png_IN,NA,50d1b14d5c5b951f

--- a/_targets.R
+++ b/_targets.R
@@ -40,13 +40,13 @@ list(
   mapped_by_state_targets,
 
   # Add combiner
-  tar_combine(obs_tallies, mapped_by_state_targets[[3]],
+  tar_combine(obs_tallies, mapped_by_state_targets$tally,
               command = combine_obs_tallies(!!!.x)),
 
   # Summary combiner
   tar_combine(
     summary_state_timeseries_csv,
-    mapped_by_state_targets[[4]],
+    mapped_by_state_targets$timeseries_png,
     command = summarize_targets('3_visualize/log/summary_state_timeseries.csv', !!!.x),
     format="file"
   ),

--- a/_targets.R
+++ b/_targets.R
@@ -17,7 +17,7 @@ source("3_visualize/src/plot_data_coverage.R")
 source("3_visualize/src/map_timeseries.R")
 
 # Configuration
-states <- c('WI','MN','MI', 'IL', 'IN')
+states <- c('WI','MN','MI', 'IL', 'IN', "KY")
 parameter <- c('00060')
 
 # Static Branching
@@ -29,7 +29,8 @@ mapped_by_state_targets <- tar_map(
     tar_target(nwis_inventory, filter(oldest_active_sites, state_cd == state_abb)),
     tar_target(nwis_data, get_site_data(nwis_inventory, state_abb, parameter)),
     tar_target(tally, tally_site_obs(nwis_data)),
-    tar_target(timeseries_png, plot_site_data(state_plot_files, nwis_data, parameter))
+    tar_target(timeseries_png, plot_site_data(state_plot_files, nwis_data, parameter),
+               format = "file")
   )
 
 list(

--- a/_targets.R
+++ b/_targets.R
@@ -4,32 +4,57 @@ library(tibble)
 suppressPackageStartupMessages(library(tidyverse))
 
 options(tidyverse.quiet = TRUE)
-tar_option_set(packages = c("tidyverse", "dataRetrieval", "urbnmapr", "rnaturalearth", "cowplot", "lubridate"))
+tar_option_set(packages = c("tidyverse", "dataRetrieval", "urbnmapr", "rnaturalearth", "cowplot", "lubridate", "leaflet", "leafpop", "htmlwidgets"))
 
 # Load functions needed by targets below
 source("1_fetch/src/find_oldest_sites.R")
 source("1_fetch/src/get_site_data.R")
 source("2_process/src/tally_site_obs.R")
+source("2_process/src/summarize_targets.R")
 source("3_visualize/src/map_sites.R")
 source("3_visualize/src/plot_site_data.R")
+source("3_visualize/src/plot_data_coverage.R")
+source("3_visualize/src/map_timeseries.R")
 
 # Configuration
-states <- c('WI','MN','MI', 'IL', 'IN', 'IA')
+states <- c('WI','MN','MI', 'IL', 'IN')
 parameter <- c('00060')
 
-
-# Targets
-list(
-  # Identify oldest sites
-  tar_target(oldest_active_sites, find_oldest_sites(states, parameter)),
-  tar_map(
+# Static Branching
+mapped_by_state_targets <- tar_map(
+  unlist=FALSE,
     values = tibble(state_abb = states) %>%
       mutate(state_plot_files = sprintf("3_visualize/out/timeseries_%s.png", state_abb)),
+    names = state_abb,
     tar_target(nwis_inventory, filter(oldest_active_sites, state_cd == state_abb)),
     tar_target(nwis_data, get_site_data(nwis_inventory, state_abb, parameter)),
     tar_target(tally, tally_site_obs(nwis_data)),
-    tar_target(timeseries_png, plot_site_data(state_plot_files, nwis_data, parameter)),
-    names = state_abb
+    tar_target(timeseries_png, plot_site_data(state_plot_files, nwis_data, parameter))
+  )
+
+list(
+  # Identify oldest sites
+  tar_target(oldest_active_sites, find_oldest_sites(states, parameter)),
+
+  mapped_by_state_targets,
+
+  # Add combiner
+  tar_combine(obs_tallies, mapped_by_state_targets[[3]],
+              command = combine_obs_tallies(!!!.x)),
+
+  # Summary combiner
+  tar_combine(
+    summary_state_timeseries_csv,
+    mapped_by_state_targets[[4]],
+    command = summarize_targets('3_visualize/log/summary_state_timeseries.csv', !!!.x),
+    format="file"
+  ),
+
+  # Plotting data coverage
+  tar_target(
+    plot_data_coverage_png,
+    plot_data_coverage(obs_tallies, "3_visualize/out/data_coverage.png", parameter),
+    format = "file"
   ),
 
 
@@ -38,5 +63,13 @@ list(
     site_map_png,
     map_sites("3_visualize/out/site_map.png", oldest_active_sites),
     format = "file"
+  ),
+
+  # Leaflet map
+  tar_target(
+    timeseries_map_html,
+    map_timeseries(oldest_active_sites, summary_state_timeseries_csv, "3_visualize/out/timeseries_map.html"),
+    format = "file"
   )
+
 )


### PR DESCRIPTION
## Summary
Following along with issue #10, I added :
- ```mapped_by_states_target``` as a ```tar_map()``` to be able to add my combiners. 
-  summary target of outputs ```summary_state_timeseries_csv``` and added the associated function ```2_process/src/summarize_targets.R```. 
- leaflet map as the ```timeseries_map_html``` target which exports an html of a map with gage locations and associated discharge figures. 
- Updated .gitignore to ignore ```/out/``` files.

_Share a screenshot of 3_visualize/out/timeseries_map.html and any thoughts you want to share in the PR description._
![leaflet](https://user-images.githubusercontent.com/69014273/187795103-b7e66176-ba48-4f6d-b1a4-c28fb9e65450.PNG)
So fun seeing how the pipeline works to create this fun leaflet map 😊